### PR TITLE
Add missiong version to formula

### DIFF
--- a/kitops.rb
+++ b/kitops.rb
@@ -2,7 +2,8 @@ class Kitops < Formula
   desc "Packaging and versioning system for AI/ML projects"
   homepage "https://KitOps.ml"
   license "Apache-2.0"
-
+  version "1.4.0"
+ 
   on_macos do
     on_arm do
       url "https://github.com/kitops-ml/kitops/releases/download/v1.4.0/kitops-darwin-arm64.tar.gz"

--- a/kitops.rb.template
+++ b/kitops.rb.template
@@ -2,7 +2,8 @@ class Kitops < Formula
   desc "Packaging and versioning system for AI/ML projects"
   homepage "https://KitOps.ml"
   license "Apache-2.0"
-
+  version "@@version"
+ 
   on_macos do
     on_arm do
       url @@darwin-arm64


### PR DESCRIPTION
Updates both the formula and the template to include the version. Brew can not identify the updated version without it