### PR TITLE
Proxy KitOps binary downloads through Scarf.sh telemetry

### DIFF
--- a/create-homebrew-recipe.awk
+++ b/create-homebrew-recipe.awk
@@ -10,6 +10,8 @@ BEGIN {
   # (intended to be homebrew-metadata.txt)
   shas[$3]=$1;
   urls[$3]=$2;
+  # Rewrite GitHub release URLs to go through Scarf for download tracking
+  gsub("https://github.com/kitops-ml/kitops/releases/download/", "https://kitops.gateway.scarf.sh/", urls[$3]);
   version[$3]=$4;
 }
 

--- a/kitops.rb
+++ b/kitops.rb
@@ -6,27 +6,26 @@ class Kitops < Formula
 
   on_macos do
     on_arm do
-      url "https://github.com/kitops-ml/kitops/releases/download/v1.15.0/kitops-darwin-arm64.tar.gz"
+      url "https://kitops.gateway.scarf.sh/v1.15.0/kitops-darwin-arm64.tar.gz"
       sha256 "c0c087e464f4559b848c8e774410c1d52c0810d71ea6c4a0b7d28bbc5baf6d64"
     end
     on_intel do
-      url "https://github.com/kitops-ml/kitops/releases/download/v1.15.0/kitops-darwin-x86_64.tar.gz"
+      url "https://kitops.gateway.scarf.sh/v1.15.0/kitops-darwin-x86_64.tar.gz"
       sha256 "f0ec1ae6c601ecb63082a9a95b819908218c3876d29aebc1f085cfe252c9290a"
     end
-
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/kitops-ml/kitops/releases/download/v1.15.0/kitops-linux-arm64.tar.gz"
+      url "https://kitops.gateway.scarf.sh/v1.15.0/kitops-linux-arm64.tar.gz"
       sha256 "0bb113d20588660f53c865f08e4beb93b72278afddae5290832dcf1ef9b93ab5"
     end
     on_intel do
       if Hardware::CPU.is_64_bit?
-        url "https://github.com/kitops-ml/kitops/releases/download/v1.15.0/kitops-linux-x86_64.tar.gz"
+        url "https://kitops.gateway.scarf.sh/v1.15.0/kitops-linux-x86_64.tar.gz"
         sha256 "c95ab7cfe1a57fcb37101454ff1d5b2783781a72cbbb4016018a701c892bf26f"
       else
-        url "https://github.com/kitops-ml/kitops/releases/download/v1.15.0/kitops-linux-i386.tar.gz"
+        url "https://kitops.gateway.scarf.sh/v1.15.0/kitops-linux-i386.tar.gz"
         sha256 "b5ca577dd79d2582f64add60d9f9929a8d7b9fbcd28f70e5ff3905d924808238"
       end
     end


### PR DESCRIPTION
Adopt scarf.sh as a telemetry solution for KitOps, as supported by CNCF. Downloads for release artifacts will now be proxied through a scarf.sh package. For information on scarf.sh, see [1].

[1] https://about.scarf.sh/